### PR TITLE
Add a batch mode for CI purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Options:
 |apiKey                |true    |N/A                  |
 |projectName           |true    |N/A                  |
 |projectVersion        |true    |N/A                  |
-|failOnError           |false   |false                |  
+|failOnError           |false   |false                |
+|batchMode             |false   |false                |
 |waitUntilBomProcessingComplete|false|false           |
 
 #### Example

--- a/config.js
+++ b/config.js
@@ -5,6 +5,7 @@ exports.config = {
   projectVersion: '',
   failOnError: true,
   bomFilepath: '.',
+  batchMode: false,
   waitUntilBomProcessingComplete: false,
   findingsThreshold: {
     critical: -1,

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const projectService = require('./services/project-service');
 const findingsService = require('./services/findings-service');
 const metricsService = require('./services/metrics-service');
 const {config} = require('./config');
-const {showProgressBarAnimation} = require('./utils/misc-utils')
+const {showProgressBarAnimation, sleep} = require('./utils/misc-utils')
 const {isEmpty, isNotEmpty} = require('./utils/string-utils')
 
 const filterByProjectVersion = (projects) => {
@@ -73,7 +73,7 @@ exports.findings = async(callback) => {
 * Dependency Track
 */
 exports.uploadbom = async() => {
-  const {bomFilepath, projectName, projectVersion, waitUntilBomProcessingComplete, failOnError} = config
+  const {bomFilepath, projectName, projectVersion, waitUntilBomProcessingComplete, batchMode, failOnError} = config
 
   if (!fs.existsSync(bomFilepath)) {
       throw new Error('Bom file not found.');
@@ -93,7 +93,11 @@ exports.uploadbom = async() => {
   while (waitUntilBomProcessingComplete && isBeingProcessed) {
       const bomProcessedResponse = await bomService.isBeingProcessed(token);
       isBeingProcessed = bomProcessedResponse.processing;
-      await showProgressBarAnimation("Processing BOM:", 5000);
+      if (!batchMode) {
+        await showProgressBarAnimation("Processing BOM:", 5000);
+      } else {
+        await sleep(5000);
+      }
   }
 
   return response;


### PR DESCRIPTION
When running uploadbom cmd on a CI platform, display progress bar flood console logs.

This PR add a the property ```batchMode``` in the config file to disable progress when setup to true.